### PR TITLE
Update metadata.json

### DIFF
--- a/Hide_Activities@shay.shayel.org/metadata.json
+++ b/Hide_Activities@shay.shayel.org/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.8"],
+    "shell-version": ["3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"],
     "uuid": "Hide_Activities@shay.shayel.org",
     "name": "Hide Activities Button",
     "description": "Hides the Activities button from the status bar"


### PR DESCRIPTION
Add support for GNOME Shell 3.10-20, as it's currently marked as "outdated" on GNOME Shell extensions web-site.